### PR TITLE
Add automated post-release PRs workflow

### DIFF
--- a/.github/scripts/release-workflow-package-push.sh
+++ b/.github/scripts/release-workflow-package-push.sh
@@ -46,6 +46,11 @@ while IFS="" read -r -d "" buildpack_toml_path; do
 		image_name="${buildpack_docker_repository}:${buildpack_version}"
 		pack package-buildpack --config "${buildpack_path}/package.toml" --publish "${image_name}"
 
+		# We might have local changes after shimming the buildpack. To ensure scripts down the pipeline work with
+		# a clean state, we reset all local changes here.
+		git reset --hard
+		git clean -fdx
+
 		echo "::set-output name=id::${buildpack_id}"
 		echo "::set-output name=version::${buildpack_version}"
 		echo "::set-output name=path::${buildpack_path}"

--- a/.github/scripts/release-workflow-prepare-pr.sh
+++ b/.github/scripts/release-workflow-prepare-pr.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+released_buildpack_id="${1:?}"
+released_buildpack_version="${2:?}"
+
+released_buildpack_next_version=$(
+	echo "${released_buildpack_version}" | awk -F. -v OFS=. '{ $NF=sprintf("%d\n", ($NF+1)); printf $0 }'
+)
+
+function escape_for_sed() {
+	echo "${1:?}" | sed 's/[]\/\[\.]/\\&/g'
+}
+
+function is_meta_buildpack_with_dependency() {
+	local -r buildpack_toml_path="${1:?}"
+	local -r buildpack_id="${2:?}"
+
+	yj -t <"${buildpack_toml_path}" | jq -e "[.order[]?.group[]?.id | select(. == \"${buildpack_id}\")] | length > 0" >/dev/null
+}
+
+# This is the heading we're looking for when updating CHANGELOG.md files
+unreleased_heading=$(escape_for_sed "## [Unreleased]")
+
+while IFS="" read -r -d "" buildpack_toml_path; do
+	buildpack_id="$(yj -t <"${buildpack_toml_path}" | jq -r .buildpack.id)"
+	buildpack_changelog_path="$(dirname "${buildpack_toml_path}")/CHANGELOG.md"
+
+	jq_filter="."
+
+	# Update the released buildpack itself
+	if [[ "${buildpack_id}" == "${released_buildpack_id}" ]]; then
+		if [[ -f "${buildpack_changelog_path}" ]]; then
+			new_version_heading=$(escape_for_sed "## [${released_buildpack_version}] $(date +%Y/%m/%d)")
+			sed -i "s/${unreleased_heading}/${unreleased_heading}\n\n${new_version_heading}/" "${buildpack_changelog_path}"
+		fi
+
+		jq_filter=".buildpack.version = \"${released_buildpack_next_version}\""
+
+	# Update meta-buildpacks that have the released buildpack as a dependency
+	elif is_meta_buildpack_with_dependency "${buildpack_toml_path}" "${released_buildpack_id}"; then
+		if [[ -f "${buildpack_changelog_path}" ]]; then
+			upgrade_entry=$(
+				escape_for_sed "* Upgraded \`${released_buildpack_id}\` to \`${released_buildpack_next_version}\`"
+			)
+
+			sed -i "s/${unreleased_heading}/${unreleased_heading}\n${upgrade_entry}/" "${buildpack_changelog_path}"
+		fi
+
+		jq_filter=$(
+			cat <<-EOF
+				.order |= map(.group |= map(
+					if .id == "${released_buildpack_id}" then
+						.version |= "${released_buildpack_next_version}"
+					else
+						.
+					end
+				))
+			EOF
+		)
+	fi
+
+	# Write the filtered buildpack.toml to disk...
+	updated=$(yj -t <"${buildpack_toml_path}" | jq "${jq_filter}" | yj -jt)
+	echo "${updated}" >"${buildpack_toml_path}"
+
+done < <(find . -name buildpack.toml -print0)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,3 +52,17 @@ jobs:
             Find the changelog here: [CHANGELOG](${{ steps.package.outputs.path }}/CHANGELOG.md)
           draft: false
           prerelease: false
+      - id: prepare-pr
+        name: "Prepare PR with version bumps and CHANGELOG updates"
+        run: ./.github/scripts/release-workflow-prepare-pr.sh "${{ steps.package.outputs.id }}" "${{ steps.package.outputs.version }}"
+        shell: bash
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          title: "Post-release updates: ${{ steps.package.outputs.id }} ${{ steps.package.outputs.version }}"
+          commit-message: "Post-release updates: ${{ steps.package.outputs.id }} ${{ steps.package.outputs.version }}"
+          branch-suffix: "random"
+          labels: "automation"
+          body: |
+            Automated pull-request to update buildpack versions and changelogs
+            after releasing version `${{ steps.package.outputs.version }}` of `${{ steps.package.outputs.id }}`.

--- a/buildpacks/nodejs/CHANGELOG.md
+++ b/buildpacks/nodejs/CHANGELOG.md
@@ -2,11 +2,11 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## main
+## [Unreleased]
 - Replace logging style to match style guides ([#63](https://github.com/heroku/nodejs-engine-buildpack/pull/63))
 - Change log colors to use ANSI codes ([#65](https://github.com/heroku/nodejs-engine-buildpack/pull/65))
 
-## 0.7.0 (2020-11-11)
+## [0.7.0] (2020-11-11)
 ### Added
 - Add support for heroku-20 ([#60](https://github.com/heroku/nodejs-engine-buildpack/pull/60))
 
@@ -14,18 +14,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove jq installation ([#57](https://github.com/heroku/nodejs-engine-buildpack/pull/57))
 - Make `NODE_ENV` variables overrides ([#61](https://github.com/heroku/nodejs-engine-buildpack/pull/61))
 
-## 0.6.0 (2020-10-13)
+## [0.6.0] (2020-10-13)
 ### Added
 - Add profile.d script ([#53](https://github.com/heroku/nodejs-engine-buildpack/pull/53))
 - Set NODE_ENV to production at runtime ([#54](https://github.com/heroku/nodejs-engine-buildpack/pull/54))
 - Set NODE_ENV in build environment ([#55](https://github.com/heroku/nodejs-engine-buildpack/pull/55))
 
-## 0.5.0 (2020-07-16)
+## [0.5.0] (2020-07-16)
 ### Added
 - Increase `MaxKeys` for listing S3 objects in `resolve-version` query ([#43](https://github.com/heroku/nodejs-engine-buildpack/pull/43))
 - Add Circle CI test integration ([#49](https://github.com/heroku/nodejs-engine-buildpack/pull/49))
 
-## 0.4.4 (2020-03-25)
+## [0.4.4] (2020-03-25)
 ### Added
 - Add shpec to shellcheck ([#38](https://github.com/heroku/nodejs-engine-buildpack/pull/38))
 - Dockerize unit tests with shpec ([#39](https://github.com/heroku/nodejs-engine-buildpack/pull/39))
@@ -34,20 +34,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Upgrade Go version to 1.14 ([#40](https://github.com/heroku/nodejs-engine-buildpack/pull/40))
 - Use cached bootstrap binaries when present ([#42](https://github.com/heroku/nodejs-engine-buildpack/pull/42))
 
-## 0.4.3 (2020-02-24)
+## [0.4.3] (2020-02-24)
 ### Fixed
 - Remove catching of unbound variables in `lib/build.sh` ([#36](https://github.com/heroku/nodejs-engine-buildpack/pull/36))
 
-## 0.4.2 (2020-01-30)
+## [0.4.2] (2020-01-30)
 ### Added
 - Write bootstrapped binaries to a layer instead of to `bin`; Add a logging method for build output ([#34](https://github.com/heroku/nodejs-engine-buildpack/pull/34))
 - Added `provides` and `requires` of `node` to buildplan. ([#31](https://github.com/heroku/nodejs-engine-buildpack/pull/31))
 
-## 0.4.1 (2019-11-08)
+## [0.4.1] (2019-11-08)
 ### Fixed
 - Fix updates to `nodejs.toml` when layer contents not updated ([#27](https://github.com/heroku/nodejs-engine-buildpack/pull/27))
 
-## 0.4.0 (2019-10-31)
+## [0.4.0] (2019-10-31)
 ### Added
 - Add launch.toml support to engine ([#26](https://github.com/heroku/nodejs-engine-buildpack/pull/26))
 - Parse engines and add them to nodejs.toml ([#25](https://github.com/heroku/nodejs-engine-buildpack/pull/25))

--- a/buildpacks/nodejs/buildpack.toml
+++ b/buildpacks/nodejs/buildpack.toml
@@ -2,7 +2,7 @@ api = "0.2"
 
 [buildpack]
 id = "heroku/nodejs-engine"
-version = "0.7.0"
+version = "0.7.1"
 name = "Node Buildpack"
 
 [[stacks]]

--- a/buildpacks/npm/CHANGELOG.md
+++ b/buildpacks/npm/CHANGELOG.md
@@ -2,16 +2,16 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## main
+## [Unreleased]
 - Ensure prefix directory exists ([#42](https://github.com/heroku/nodejs-npm-buildpack/pull/44))
 - Use new logging style ([#45](https://github.com/heroku/nodejs-npm-buildpack/pull/45))
 - Change log colors to use ANSI codes ([#47](https://github.com/heroku/nodejs-npm-buildpack/pull/47))
 
-## 0.4.0 (2020-11-11)
+## [0.4.0] (2020-11-11)
 ### Added
 - Add heroku-20 to supported stacks ([#40](https://github.com/heroku/nodejs-npm-buildpack/pull/40))
 
-## 0.3.0 (2020-09-16)
+## [0.3.0] (2020-09-16)
 ### Added
 - Prune devdependencies ([#32](https://github.com/heroku/nodejs-npm-buildpack/pull/32))
 - Opt out of pruning devdependencies if NODE_ENV is not production ([#33](https://github.com/heroku/nodejs-npm-buildpack/pull/33))
@@ -20,36 +20,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Move integration testing to CirleCI ([#37](https://github.com/heroku/nodejs-npm-buildpack/pull/37))
 
-## 0.2.0 (2020-05-19)
+## [0.2.0] (2020-05-19)
 ### Added
 - docs: add docs around `Permission denied` issues ([#28](https://github.com/heroku/nodejs-npm-buildpack/pull/28))
 - Add dockerized unit tests ([#29](https://github.com/heroku/nodejs-npm-buildpack/pull/29))
 - Added `provides` and `requires` of `node_modules` and `node` to buildplan. ([#18](https://github.com/heroku/nodejs-npm-buildpack/pull/18))
 
-## 0.1.4 (2020-02-19)
+## [0.1.4] (2020-02-19)
 ### Added
 - feat: install `npm` version specified in `package.json` ([#24](https://github.com/heroku/nodejs-npm-buildpack/pull/24))
 - feat: exchange echo commands for `log_info` method ([#25](https://github.com/heroku/nodejs-npm-buildpack/pull/25))
 ### Fixed
 - fix: use_npm_ci expression return value id ([#22](https://github.com/heroku/nodejs-npm-buildpack/pull/23))
 
-## 0.1.3 (2020-01-28)
+## [0.1.3] (2020-01-28)
 ### Fixed
 - fix: remove `-buildpack` from buildpack id ([#16](https://github.com/heroku/nodejs-npm-buildpack/pull/16))
 - feat: support running on `io.buildpacks.stacks.bionic` stack ([#17](https://github.com/heroku/nodejs-npm-buildpack/pull/17))
 
-## 0.1.2 (2019-11-01)
+## [0.1.2] (2019-11-01)
 ### Added
 - feat: support build time environment variables ([#14](https://github.com/heroku/nodejs-npm-buildpack/pull/14))
 
-## 0.1.1 (2019-10-30)
+## [0.1.1] (2019-10-30)
 ### Fixed
 - Fix copying node_modules when a `package-lock.json` is present ([#12](https://github.com/heroku/nodejs-npm-buildpack/pull/12))
 
-## 0.1.0 (2019-10-29)
+## [0.1.0] (2019-10-29)
 ### Added
 - feat: use `npm start` as the default launch.toml ([#11](https://github.com/heroku/nodejs-npm-buildpack/pull/11))
 
-## 0.0.2 (2019-10-11)
+## [0.0.2] (2019-10-11)
 ### Fixed
 - Fix broken builds when a `package-lock.json` is missing ([#9](https://github.com/heroku/nodejs-npm-buildpack/pull/9))

--- a/buildpacks/npm/buildpack.toml
+++ b/buildpacks/npm/buildpack.toml
@@ -2,7 +2,7 @@ api = "0.2"
 
 [buildpack]
 id = "heroku/nodejs-npm"
-version = "0.4.0"
+version = "0.4.1"
 name = "NPM Buildpack"
 
 [[stacks]]

--- a/buildpacks/typescript/CHANGELOG.md
+++ b/buildpacks/typescript/CHANGELOG.md
@@ -2,23 +2,23 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## main
+## [Unreleased]
 
-## v0.2.0
+## [0.2.0]
 ### Added
 - Add heroku-20 support and stack-specific tests ([#13](https://github.com/heroku/nodejs-typescript-buildpack/pull/13))
 
-## v0.1.0
+## [0.1.0]
 ### Added
 - detect if custom tsconfig env var is set ([#10](https://github.com/heroku/nodejs-typescript-buildpack/pull/10))
 - change master to main ([#11](https://github.com/heroku/nodejs-typescript-buildpack/pull/11))
 
-## v0.0.2
+## [0.0.2]
 ### Added
 - check if tsc binary is present in the build ([#6](https://github.com/heroku/nodejs-typescript-buildpack/pull/6))
 - add typescript binary to PATH ([#7](https://github.com/heroku/nodejs-typescript-buildpack/pull/7))
 
-## v0.0.1
+## [0.0.1]
 ### Added
 - add the $layers_dir argument to bin/build ([#3](https://github.com/heroku/nodejs-typescript-buildpack/pull/3))
 - detect outDir directory from tsconfig.json ([#4](https://github.com/heroku/nodejs-typescript-buildpack/pull/4))

--- a/buildpacks/typescript/buildpack.toml
+++ b/buildpacks/typescript/buildpack.toml
@@ -2,7 +2,7 @@ api = "0.2"
 
 [buildpack]
 id = "heroku/nodejs-typescript"
-version = "0.2.2"
+version = "0.2.1"
 name = "TypeScript Buildpack"
 
 [[stacks]]

--- a/buildpacks/typescript/buildpack.toml
+++ b/buildpacks/typescript/buildpack.toml
@@ -2,7 +2,7 @@ api = "0.2"
 
 [buildpack]
 id = "heroku/nodejs-typescript"
-version = "0.2.0"
+version = "0.2.2"
 name = "TypeScript Buildpack"
 
 [[stacks]]

--- a/buildpacks/yarn/CHANGELOG.md
+++ b/buildpacks/yarn/CHANGELOG.md
@@ -2,12 +2,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-# main
+# [Unreleased]
 
-## 0.1.0 (2020-11-11)
+## [0.1.0] (2020-11-11)
 ### Added
 - Add support for heroku-20 and bionic stacks ([#4](https://github.com/heroku/nodejs-yarn-buildpack/pull/4))
 
-## 0.0.1 (2019-12-08)
+## [0.0.1] (2019-12-08)
 ### Added
 - Changelog entry for first release ([#1](https://github.com/heroku/nodejs-yarn-buildpack/pull/1))

--- a/buildpacks/yarn/buildpack.toml
+++ b/buildpacks/yarn/buildpack.toml
@@ -2,7 +2,7 @@ api = "0.2"
 
 [buildpack]
 id = "heroku/nodejs-yarn"
-version = "0.1.0"
+version = "0.1.1"
 name = "Yarn Buildpack"
 
 [[stacks]]

--- a/meta-buildpacks/nodejs/CHANGELOG.md
+++ b/meta-buildpacks/nodejs/CHANGELOG.md
@@ -1,4 +1,4 @@
-## main
+## [Unreleased]
 
-# 0.1.1
+# [0.1.1]
 * Initial release

--- a/meta-buildpacks/nodejs/buildpack.toml
+++ b/meta-buildpacks/nodejs/buildpack.toml
@@ -8,15 +8,15 @@ name = "Node.js"
 [[order]]
 [[order.group]]
 id = "heroku/nodejs-engine"
-version = "0.7.0"
+version = "0.7.1"
 
 [[order.group]]
 id = "heroku/nodejs-yarn"
-version = "0.1.0"
+version = "0.1.1"
 
 [[order.group]]
 id = "heroku/nodejs-typescript"
-version = "0.2.0"
+version = "0.2.1"
 optional = true
 
 [[order.group]]
@@ -27,15 +27,15 @@ optional = true
 [[order]]
 [[order.group]]
 id = "heroku/nodejs-engine"
-version = "0.7.0"
+version = "0.7.1"
 
 [[order.group]]
 id = "heroku/nodejs-npm"
-version = "0.4.0"
+version = "0.4.1"
 
 [[order.group]]
 id = "heroku/nodejs-typescript"
-version = "0.2.0"
+version = "0.2.1"
 optional = true
 
 [[order.group]]


### PR DESCRIPTION
Port of https://github.com/heroku/buildpacks-jvm/pull/16

TODO:
- [x] Update CHANGELOGs to contain a `[Unreleased]` section
- [x] Bump all buildpack versions in their `buildpack.toml`s to be at the next version