### PR TITLE
Port build script support from buildpacks-jvm

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,11 +2,26 @@ version: 2.1
 
 orbs:
   pack: buildpacks/pack@0.2.2
+  heroku-buildpacks:
+    commands:
+      install-build-dependencies:
+        steps:
+          - run:
+              name: "Install rsync, jq via apt"
+              command: sudo apt-get update && sudo apt-get install -y rsync jq
+          - run:
+              name: "Install yj 5.0.0"
+              command: |
+                bin_dir="$(mktemp -d)"
+                curl --retry 3 --fail --max-time 10 --location "https://github.com/sclevine/yj/releases/download/v5.0.0/yj-linux" --output "${bin_dir}/yj"
+                chmod +x "${bin_dir}/yj"
+
+                echo "export PATH=\"${bin_dir}:\${PATH}\"" >> $BASH_ENV
 
 jobs:
   package-buildpack:
     parameters:
-      package-toml:
+      buildpack-dir:
         type: string
     docker:
       - image: cimg/base:2020.01
@@ -15,7 +30,17 @@ jobs:
       - setup_remote_docker
       - pack/install-pack:
           version: 0.16.0
-      - run: pack package-buildpack test --config << parameters.package-toml >>
+      - heroku-buildpacks/install-build-dependencies
+      - run:
+          name: "Build and package buildpack"
+          command: |
+            package_toml="<< parameters.buildpack-dir >>/package.toml"
+            if [[ -f "<< parameters.buildpack-dir >>/build.sh" ]]; then
+              "./<< parameters.buildpack-dir >>/build.sh"
+              package_toml="<< parameters.buildpack-dir >>/target/package.toml"
+            fi
+
+            pack buildpack package test --config "${package_toml}"
 
   shell-linting:
     docker:
@@ -69,5 +94,8 @@ workflows:
       - package-buildpack:
           matrix:
             parameters:
-              package-toml:
-                - "meta-buildpacks/nodejs/package.toml"
+              buildpack-dir:
+                - "buildpacks/nodejs"
+                - "buildpacks/npm"
+                - "buildpacks/typescript"
+                - "meta-buildpacks/nodejs"

--- a/.github/scripts/release-workflow-package-push.sh
+++ b/.github/scripts/release-workflow-package-push.sh
@@ -13,41 +13,22 @@ while IFS="" read -r -d "" buildpack_toml_path; do
 	buildpack_path=$(dirname "${buildpack_toml_path}")
 
 	if [[ $buildpack_id == "${REQUESTED_BUILDPACK_ID}" ]]; then
-		cnb_shim_tarball_url="https://github.com/heroku/cnb-shim/releases/download/v0.3/cnb-shim-v0.3.tgz"
-		cnb_shim_tarball_sha256="109cfc01953cb04e69c82eec1c45c7c800bd57d2fd0eef030c37d8fc37a1cb4d"
-		local_cnb_shim_tarball=$(mktemp)
+		# Some buildpacks require a build step before packaging. If we detect a build.sh script, we execute it and
+		# modify some variables to point to the directory with the built buildpack instead.
+		if [[ -f "${buildpack_path}/build.sh" ]]; then
+			echo "Buildpack has build script, executing..."
+			"${buildpack_path}/build.sh"
+			echo "Build finished!"
 
-		v2_buildpack_tarball_url="$(yj -t <"${buildpack_toml_path}" | jq -r ".metadata.shim.tarball // empty")"
-		v2_buildpack_tarball_sha256="$(yj -t <"${buildpack_toml_path}" | jq -r ".metadata.shim.sha256 // empty")"
-		local_v2_buildpack_tarball=$(mktemp)
-
-		# If the buildpack has a V2 buildpack tarball in its metadata it's supposed to be a shimmed buildpack.
-		# We download the shim and the V2 buildpack to the buildpack directory, turning it into a CNB. This
-		# transformation is transparent for the code that follows after it.
-		if [[ -n "${v2_buildpack_tarball_url:-}" ]]; then
-			curl --retry 3 --location "${cnb_shim_tarball_url}" --output "${local_cnb_shim_tarball}"
-			curl --retry 3 --location "${v2_buildpack_tarball_url}" --output "${local_v2_buildpack_tarball}"
-
-			if ! echo "${cnb_shim_tarball_sha256} ${local_cnb_shim_tarball}" | sha256sum --check --status; then
-				echo "Checksum verification of cnb_shim failed!"
-				exit 1
-			fi
-
-			if ! echo "${v2_buildpack_tarball_sha256} ${local_v2_buildpack_tarball}" | sha256sum --check --status; then
-				echo "Checksum verification of V2 buildpack tarball failed!"
-				exit 1
-			fi
-
-			mkdir -p "${buildpack_path}/target"
-			tar -xzmf "${local_cnb_shim_tarball}" -C "${buildpack_path}"
-			tar -xzmf "${local_v2_buildpack_tarball}" -C "${buildpack_path}/target"
+			buildpack_path="${buildpack_path}/target"
+			buildpack_toml_path="${buildpack_path}/buildpack.toml"
 		fi
 
 		image_name="${buildpack_docker_repository}:${buildpack_version}"
 		pack package-buildpack --config "${buildpack_path}/package.toml" --publish "${image_name}"
 
-		# We might have local changes after shimming the buildpack. To ensure scripts down the pipeline work with
-		# a clean state, we reset all local changes here.
+		# We might have local changes after building and/or shimming the buildpack. To ensure scripts down the pipeline
+		# work with a clean state, we reset all local changes here.
 		git reset --hard
 		git clean -fdx
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea
+**/target/

--- a/README.md
+++ b/README.md
@@ -24,5 +24,19 @@ use the links below for your convenience.
 
 - [heroku/nodejs](https://github.com/heroku/heroku-buildpack-nodejs)
 
+## Building
+Many of the buildpacks in this repository require a separate build step before they can be used. By convention, build
+scripts must be located in a file named `build.sh` in the buildpack root directory.
+
+### Build script conventions
+`build.sh` scripts:
+- **MUST NOT** depend on a specific working directory and can be called from anywhere
+- **MUST** write the finished buildpack to `target/` within the buildpack directory
+
+### Dependencies
+- [Bash](https://www.gnu.org/software/bash/) >= `5.0`
+- [yj](https://github.com/sclevine/yj) >= `5.0.0` in `$PATH`
+- [jq](https://github.com/stedolan/jq) >= `1.6` in `$PATH`
+
 ## License
 Licensed under the MIT License. See [LICENSE](./LICENSE) file.

--- a/common/meta-build.sh
+++ b/common/meta-build.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Builds a meta buildpack by copying itself to the target directory. Since dependent buildpacks
+# might also need to be build before packaging, this script will also look for local buildpack references in
+# package.toml, execute their build script if present and modifies the meta-buildpack's package.toml
+# (within the target directory) to point to the built version of the of the dependency.
+
+buildpack_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+target_dir_name="target"
+target_dir="${buildpack_dir}/${target_dir_name}"
+
+mkdir "${target_dir}"
+rsync -a -L "${buildpack_dir}/" "${target_dir}" --exclude "${target_dir_name}"
+
+if [[ -f "${buildpack_dir}/package.toml" ]]; then
+	original_dependency_uris=$(yj -t <"${buildpack_dir}/package.toml" | jq -r .dependencies[].uri)
+	for original_dependency_uri in ${original_dependency_uris}; do
+
+		if (cd "${buildpack_dir}" && realpath -q "${original_dependency_uri}"); then
+			# Absolute path to the referenced buildpack
+			dependency_buildpack_dir="$(cd "${buildpack_dir}" && realpath "${original_dependency_uri}")"
+
+			if [[ -d "${dependency_buildpack_dir}" && -f "${dependency_buildpack_dir}/build.sh" ]]; then
+				echo "Building buildpack at ${dependency_buildpack_dir}..."
+				"${dependency_buildpack_dir}/build.sh"
+				echo "Build complete!"
+
+				updated_dependency_uri="$(
+					realpath --relative-to "${target_dir}" "${dependency_buildpack_dir}/target"
+				)"
+
+				jq_filter=".dependencies |= map(select(.uri == \"${original_dependency_uri}\").uri |= \"${updated_dependency_uri}\")"
+
+				updated_package_toml=$(yj -t <"${target_dir}/package.toml" | jq "${jq_filter}" | yj -jt)
+				echo "${updated_package_toml}" >"${target_dir}/package.toml"
+			fi
+		fi
+	done
+fi

--- a/common/rsync-build.sh
+++ b/common/rsync-build.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Copies the whole buildpack to the target directory while following symlinks.
+# Resolving symlinks to regular files is the main purpose of this "build" script.
+
+buildpack_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+target_dir_name="target"
+target_dir="${buildpack_dir}/${target_dir_name}"
+
+mkdir "${target_dir}"
+rsync -a -L "${buildpack_dir}/" "${target_dir}" --exclude "${target_dir_name}"

--- a/meta-buildpacks/nodejs/build.sh
+++ b/meta-buildpacks/nodejs/build.sh
@@ -1,0 +1,1 @@
+../../common/meta-build.sh


### PR DESCRIPTION
Port of https://github.com/heroku/buildpacks-jvm/pull/19, see that PR for a detailed description.

This adds a build script to the meta buildpack, individual buildpack scripts need to be added separately if required.