### PR TITLE
remove package.json requirement

### DIFF
--- a/buildpacks/nodejs/CHANGELOG.md
+++ b/buildpacks/nodejs/CHANGELOG.md
@@ -5,6 +5,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 - Add license to buildpack.toml ([#17](https://github.com/heroku/buildpacks-node/pull/17))
 - Copy node modules directory path into the build ENV ([#15](https://github.com/heroku/buildpacks-node/pull/15))
+- Remove package.json requirement ([#14](https://github.com/heroku/buildpacks-node/pull/14))
 
 ## [0.7.1] 2021/01/20
 - Replace logging style to match style guides ([#63](https://github.com/heroku/nodejs-engine-buildpack/pull/63))

--- a/buildpacks/nodejs/bin/detect
+++ b/buildpacks/nodejs/bin/detect
@@ -7,14 +7,9 @@ bp_dir=$(
 	cd "$(dirname "$0")"/..
 	pwd
 )
-build_dir=$(pwd)
 build_plan="$2"
 
 # shellcheck source=/dev/null
 source "$bp_dir/lib/detect.sh"
 
-if ! detect_package_json "$build_dir"; then
-	exit 100
-else
-	write_to_build_plan "$build_plan"
-fi
+write_to_build_plan "$build_plan"

--- a/buildpacks/nodejs/lib/detect.sh
+++ b/buildpacks/nodejs/lib/detect.sh
@@ -1,10 +1,5 @@
 #!/usr/bin/env bash
 
-detect_package_json() {
-	local build_dir=$1
-	[[ -f "$build_dir/package.json" ]]
-}
-
 write_to_build_plan() {
 	local build_plan=$1
 	cat <<EOF >"$build_plan"

--- a/buildpacks/nodejs/lib/detect.sh
+++ b/buildpacks/nodejs/lib/detect.sh
@@ -6,7 +6,5 @@ write_to_build_plan() {
 	[[provides]]
 	name = "node"
 
-	[[requires]]
-	name = "node"
 EOF
 }

--- a/buildpacks/nodejs/shpec/detect_shpec.sh
+++ b/buildpacks/nodejs/shpec/detect_shpec.sh
@@ -13,28 +13,6 @@ create_temp_project_dir() {
 }
 
 describe "lib/detect.sh"
-	describe "detect_package_json"
-		it "exits with 1 if there is no package.json"
-			project_dir=$(create_temp_project_dir)
-
-			set +e
-			detect_package_json "$project_dir"
-			loc_var=$?
-			set -e
-
-			assert equal "$loc_var" 1
-		end
-
-		it "exits with 0 if there is package.json"
-			project_dir=$(create_temp_project_dir)
-			touch "$project_dir/package.json"
-
-			detect_package_json "$project_dir"
-
-			assert equal "$?" 0
-		end
-	end
-
 	describe "write_to_build_plan"
 		it "writes node for [[provides]] and [[requires]]"
 			project_dir=$(create_temp_project_dir)

--- a/buildpacks/nodejs/shpec/detect_shpec.sh
+++ b/buildpacks/nodejs/shpec/detect_shpec.sh
@@ -24,8 +24,6 @@ describe "lib/detect.sh"
 	[[provides]]
 	name = "node"
 
-	[[requires]]
-	name = "node"
 EOF
 )
 			assert equal "$actual" "$expected"


### PR DESCRIPTION
# Description

Remove package.json requirement to fix downstream buildpack issues for builds that need the Node runtime, but that may not have a package.json.

# Checklist:

- [x] Run these changes with `pack`
- [x] Make updates to `CHANGELOG.md`
