### PR TITLE
copy node modules dir path into env

### DIFF
--- a/buildpacks/nodejs/CHANGELOG.md
+++ b/buildpacks/nodejs/CHANGELOG.md
@@ -3,6 +3,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Copy node modules directory path into the build ENV ([#15](https://github.com/heroku/buildpacks-node/pull/15))
 
 ## [0.7.1] 2021/01/20
 - Replace logging style to match style guides ([#63](https://github.com/heroku/nodejs-engine-buildpack/pull/63))

--- a/buildpacks/nodejs/bin/build
+++ b/buildpacks/nodejs/bin/build
@@ -39,6 +39,8 @@ fi
 
 set_node_env "$layers_dir/nodejs"
 
+set_node_modules_env "$layers_dir/node_modules"
+
 copy_profile "$layers_dir/nodejs" "$bp_dir"
 
 write_launch_toml "$build_dir" "$layers_dir/launch.toml"

--- a/buildpacks/nodejs/bin/build
+++ b/buildpacks/nodejs/bin/build
@@ -39,7 +39,7 @@ fi
 
 set_node_env "$layers_dir/nodejs"
 
-set_node_modules_env "$layers_dir/node_modules"
+set_node_modules_path "$layers_dir/node_modules"
 
 copy_profile "$layers_dir/nodejs" "$bp_dir"
 

--- a/buildpacks/nodejs/lib/build.sh
+++ b/buildpacks/nodejs/lib/build.sh
@@ -167,7 +167,10 @@ set_node_modules_env() {
 
 	mkdir -p "${layer_dir}/env"
 	if [[ ! -s "${layer_dir}/env/NODE_MODULES_ENV" ]]; then
-		echo "$(cd "$(dirname "${layer_dir}/node_modules")"; pwd -P)/$(basename "${layer_dir}/node_modules")" >>"${layer_dir}/env/NODE_MODULES_ENV"
+		echo "$(
+			cd "$(dirname "${layer_dir}/node_modules")"
+			pwd -P
+		)/$(basename "${layer_dir}/node_modules")" >>"${layer_dir}/env/NODE_MODULES_ENV"
 	fi
 }
 

--- a/buildpacks/nodejs/lib/build.sh
+++ b/buildpacks/nodejs/lib/build.sh
@@ -162,15 +162,15 @@ set_node_env() {
 	fi
 }
 
-set_node_modules_env() {
+set_node_modules_path() {
 	local layer_dir=$1
 
 	mkdir -p "${layer_dir}/env"
-	if [[ ! -s "${layer_dir}/env/NODE_MODULES_ENV" ]]; then
+	if [[ ! -s "${layer_dir}/env/NODE_MODULES_PATH" ]]; then
 		echo "$(
 			cd "$(dirname "${layer_dir}/node_modules")"
 			pwd -P
-		)/$(basename "${layer_dir}/node_modules")" >>"${layer_dir}/env/NODE_MODULES_ENV"
+		)/$(basename "${layer_dir}/node_modules")" >>"${layer_dir}/env/NODE_MODULES_PATH"
 	fi
 }
 

--- a/buildpacks/nodejs/lib/build.sh
+++ b/buildpacks/nodejs/lib/build.sh
@@ -162,6 +162,15 @@ set_node_env() {
 	fi
 }
 
+set_node_modules_env() {
+	local layer_dir=$1
+
+	mkdir -p "${layer_dir}/env"
+	if [[ ! -s "${layer_dir}/env/NODE_MODULES_ENV" ]]; then
+		echo -e "$layer_dir/node_modules" >>"${layer_dir}/env/NODE_MODULES_ENV"
+	fi
+}
+
 copy_profile() {
 	local layer_dir=$1
 	local bp_dir=$2

--- a/buildpacks/nodejs/lib/build.sh
+++ b/buildpacks/nodejs/lib/build.sh
@@ -167,7 +167,7 @@ set_node_modules_env() {
 
 	mkdir -p "${layer_dir}/env"
 	if [[ ! -s "${layer_dir}/env/NODE_MODULES_ENV" ]]; then
-		echo -e "$layer_dir/node_modules" >>"${layer_dir}/env/NODE_MODULES_ENV"
+		echo "$(cd "$(dirname "${layer_dir}/node_modules")"; pwd -P)/$(basename "${layer_dir}/node_modules")" >>"${layer_dir}/env/NODE_MODULES_ENV"
 	fi
 }
 

--- a/buildpacks/nodejs/shpec/build_shpec.sh
+++ b/buildpacks/nodejs/shpec/build_shpec.sh
@@ -89,6 +89,17 @@ describe "lib/build.sh"
 		rm_temp_dirs "$layers_dir"
 	end
 
+	describe "set_node_modules_env"
+		layers_dir=$(create_temp_layer_dir)
+		it "sets NODE_MODULES_ENV to node modules directory path"
+			assert file_absent "$layers_dir/nodejs/env/NODE_MODULES_ENV"
+
+			set_node_modules_env "$layers_dir/nodejs"
+
+			assert file_present "$layers_dir/nodejs/env/NODE_MODULES_ENV"
+		end
+	end
+
 	describe "install_or_reuse_toolbox"
 		export PATH=$layers_dir/toolbox/bin:$PATH
 

--- a/buildpacks/nodejs/shpec/build_shpec.sh
+++ b/buildpacks/nodejs/shpec/build_shpec.sh
@@ -89,14 +89,14 @@ describe "lib/build.sh"
 		rm_temp_dirs "$layers_dir"
 	end
 
-	describe "set_node_modules_env"
+	describe "set_node_modules_path"
 		layers_dir=$(create_temp_layer_dir)
-		it "sets NODE_MODULES_ENV to node modules directory path"
-			assert file_absent "$layers_dir/nodejs/env/NODE_MODULES_ENV"
+		it "sets NODE_MODULES_PATH to node modules directory path"
+			assert file_absent "$layers_dir/nodejs/env/NODE_MODULES_PATH"
 
-			set_node_modules_env "$layers_dir/nodejs"
+			set_node_modules_path "$layers_dir/nodejs"
 
-			assert file_present "$layers_dir/nodejs/env/NODE_MODULES_ENV"
+			assert file_present "$layers_dir/nodejs/env/NODE_MODULES_PATH"
 		end
 	end
 


### PR DESCRIPTION
In order to make node modules available downstream, copy the path into the build ENV for subsequent buildpacks.