### PR TITLE
bump version so it does not collide with the pack-images meta buildpack

### DIFF
--- a/meta-buildpacks/nodejs/CHANGELOG.md
+++ b/meta-buildpacks/nodejs/CHANGELOG.md
@@ -14,7 +14,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Automated post-release PRs
 ### Changed
 * Package meta buildpack with latest releases of buildpacks while testing against unreleased.
-* Bumped the version for pack-cli GitHubAction ([#18](https://github.com/heroku/buildpacks-node/pull/18))
 
 ## [0.1.1]
 * Initial release

--- a/meta-buildpacks/nodejs/buildpack.toml
+++ b/meta-buildpacks/nodejs/buildpack.toml
@@ -2,7 +2,7 @@ api = "0.2"
 
 [buildpack]
 id = "heroku/nodejs"
-version = "0.2.1"
+version = "0.3.0"
 name = "Node.js"
 
 [[buildpack.licenses]]


### PR DESCRIPTION
pack-images already has 0.2.0 as meta buildpack version, so this bumps the minor version up to 0.3.0.