### PR TITLE
Fix stack image detect

### DIFF
--- a/buildpacks/nodejs/CHANGELOG.md
+++ b/buildpacks/nodejs/CHANGELOG.md
@@ -4,6 +4,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 - Flush cache when stack image changes ([#28](https://github.com/heroku/buildpacks-node/pull/28))
+- Trim whitespace when getting stack name ([#29](https://github.com/heroku/buildpacks-node/pull/29))
 
 ## [0.7.2] 2021/02/23
 - Add license to buildpack.toml ([#17](https://github.com/heroku/buildpacks-node/pull/17))

--- a/buildpacks/nodejs/lib/build.sh
+++ b/buildpacks/nodejs/lib/build.sh
@@ -22,10 +22,10 @@ clear_cache_on_stack_change() {
 	if [[ -f "${layers_dir}/store.toml" ]]; then
 		local last_stack
 		# shellcheck disable=SC2002
-		last_stack=$(cat "${layers_dir}/store.toml" | grep last_stack | cut -d " " -f3)
+		last_stack=$(cat "${layers_dir}/store.toml" | grep last_stack | xargs | cut -d " " -f3)
 
-		if [[ "\"$CNB_STACK_ID\"" != "$last_stack" ]]; then
-			info "Deleting cache because stack changed from $last_stack to \"$CNB_STACK_ID\""
+		if [[ "$CNB_STACK_ID" != "$last_stack" ]]; then
+			info "Deleting cache because stack changed from \"$last_stack\" to \"$CNB_STACK_ID\""
 			rm -rf "${layers_dir:?}"/*
 		fi
 	fi

--- a/buildpacks/npm/CHANGELOG.md
+++ b/buildpacks/npm/CHANGELOG.md
@@ -4,6 +4,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 - Flush cache when stack image changes ([#28](https://github.com/heroku/buildpacks-node/pull/28))
+- Trim whitespace when getting stack name ([#29](https://github.com/heroku/buildpacks-node/pull/29))
 
 ## [0.4.2] 2021/02/23
 - Add license to buildpack.toml ([#17](https://github.com/heroku/buildpacks-node/pull/17))

--- a/buildpacks/npm/lib/build.sh
+++ b/buildpacks/npm/lib/build.sh
@@ -22,10 +22,10 @@ clear_cache_on_stack_change() {
 	if [[ -f "${layers_dir}/store.toml" ]]; then
 		local last_stack
 		# shellcheck disable=SC2002
-		last_stack=$(cat "${layers_dir}/store.toml" | grep last_stack | cut -d " " -f3)
+		last_stack=$(cat "${layers_dir}/store.toml" | grep last_stack | xargs | cut -d " " -f3)
 
-		if [[ "\"$CNB_STACK_ID\"" != "$last_stack" ]]; then
-			info "Deleting cache because stack changed from $last_stack to \"$CNB_STACK_ID\""
+		if [[ "$CNB_STACK_ID" != "$last_stack" ]]; then
+			info "Deleting cache because stack changed from \"$last_stack\" to \"$CNB_STACK_ID\""
 			rm -rf "${layers_dir:?}"/*
 		fi
 	fi

--- a/buildpacks/typescript/CHANGELOG.md
+++ b/buildpacks/typescript/CHANGELOG.md
@@ -4,6 +4,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 - Flush cache when stack image changes ([#28](https://github.com/heroku/buildpacks-node/pull/28))
+- Trim whitespace when getting stack name ([#29](https://github.com/heroku/buildpacks-node/pull/29))
 
 ## [0.2.1] 2021/02/23
 - Add license to buildpack.toml ([#17](https://github.com/heroku/buildpacks-node/pull/17))

--- a/buildpacks/typescript/lib/build.sh
+++ b/buildpacks/typescript/lib/build.sh
@@ -18,10 +18,10 @@ clear_cache_on_stack_change() {
 	if [[ -f "${layers_dir}/store.toml" ]]; then
 		local last_stack
 		# shellcheck disable=SC2002
-		last_stack=$(cat "${layers_dir}/store.toml" | grep last_stack | cut -d " " -f3)
+		last_stack=$(cat "${layers_dir}/store.toml" | grep last_stack | xargs | cut -d " " -f3)
 
-		if [[ "\"$CNB_STACK_ID\"" != "$last_stack" ]]; then
-			info "Deleting cache because stack changed from $last_stack to \"$CNB_STACK_ID\""
+		if [[ "$CNB_STACK_ID" != "$last_stack" ]]; then
+			info "Deleting cache because stack changed from \"$last_stack\" to \"$CNB_STACK_ID\""
 			rm -rf "${layers_dir:?}"/*
 		fi
 	fi

--- a/buildpacks/yarn/CHANGELOG.md
+++ b/buildpacks/yarn/CHANGELOG.md
@@ -5,6 +5,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 # [Unreleased]
 - Add license to buildpack.toml ([#17](https://github.com/heroku/buildpacks-node/pull/17))
 - Flush cache when stack image changes ([#28](https://github.com/heroku/buildpacks-node/pull/28))
+- Trim whitespace when getting stack name ([#29](https://github.com/heroku/buildpacks-node/pull/29))
 
 ## [0.1.1] 2021/01/20
 

--- a/buildpacks/yarn/lib/build.sh
+++ b/buildpacks/yarn/lib/build.sh
@@ -22,10 +22,10 @@ clear_cache_on_stack_change() {
 	if [[ -f "${layers_dir}/store.toml" ]]; then
 		local last_stack
 		# shellcheck disable=SC2002
-		last_stack=$(cat "${layers_dir}/store.toml" | grep last_stack | cut -d " " -f3)
+		last_stack=$(cat "${layers_dir}/store.toml" | grep last_stack | xargs | cut -d " " -f3)
 
-		if [[ "\"$CNB_STACK_ID\"" != "$last_stack" ]]; then
-			info "Deleting cache because stack changed from $last_stack to \"$CNB_STACK_ID\""
+		if [[ "$CNB_STACK_ID" != "$last_stack" ]]; then
+			info "Deleting cache because stack changed from \"$last_stack\" to \"$CNB_STACK_ID\""
 			rm -rf "${layers_dir:?}"/*
 		fi
 	fi

--- a/meta-buildpacks/nodejs/CHANGELOG.md
+++ b/meta-buildpacks/nodejs/CHANGELOG.md
@@ -3,6 +3,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+* Upgrade `heroku/procfile` to `0.6.2`
 
 ## [0.3.0] 2021/02/26
 

--- a/meta-buildpacks/nodejs/buildpack.toml
+++ b/meta-buildpacks/nodejs/buildpack.toml
@@ -25,7 +25,7 @@ optional = true
 
 [[order.group]]
 id = "heroku/procfile"
-version = "0.6.1"
+version = "0.6.2"
 optional = true
 
 [[order]]
@@ -45,7 +45,7 @@ optional = true
 
 [[order.group]]
 id = "heroku/procfile"
-version = "0.6.1"
+version = "0.6.2"
 optional = true
 
 [metadata]

--- a/meta-buildpacks/nodejs/package.toml
+++ b/meta-buildpacks/nodejs/package.toml
@@ -14,4 +14,4 @@ uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-yarn-buildpack@sh
 uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-typescript-buildpack@sha256:4e4fa2f7b2c45ee135e0c4b0ffb5dcebf9b43ea24d490699f82f95fa64229cee"
 
 [[dependencies]]
-uri = "docker://docker.io/heroku/procfile-cnb@sha256:74881b33e1e33eea38b419e667b0a99ac50e536727eeefd1b2eeb7ff3a937ffd"
+uri = "docker://docker.io/heroku/procfile-cnb@sha256:b078c148796dd3cff2bb1ac7a0632cf9f4b558bda3161cd0f869010f72c87558"

--- a/test/meta-buildpacks/nodejs/buildpack.toml
+++ b/test/meta-buildpacks/nodejs/buildpack.toml
@@ -22,7 +22,7 @@ optional = true
 
 [[order.group]]
 id = "heroku/procfile"
-version = "0.6.1"
+version = "0.6.2"
 optional = true
 
 [[order]]
@@ -42,5 +42,5 @@ optional = true
 
 [[order.group]]
 id = "heroku/procfile"
-version = "0.6.1"
+version = "0.6.2"
 optional = true

--- a/test/meta-buildpacks/nodejs/package.toml
+++ b/test/meta-buildpacks/nodejs/package.toml
@@ -15,4 +15,4 @@ uri = "../../../buildpacks/typescript"
 
 [[dependencies]]
 # Should be urn:cnb:registry:heroku/procfile@0.6.1 as soon as pack supports it. (0.16.1?)
-uri = "docker://docker.io/heroku/procfile-cnb@sha256:74881b33e1e33eea38b419e667b0a99ac50e536727eeefd1b2eeb7ff3a937ffd"
+uri = "docker://docker.io/heroku/procfile-cnb@sha256:b078c148796dd3cff2bb1ac7a0632cf9f4b558bda3161cd0f869010f72c87558"


### PR DESCRIPTION
Fixes stack image detect to clear cache when `store.toml` is stored then retrieved. It will trim the whitespace around the string when grepping from the `store.toml`.

Also updates Procfile CNB version to pull in updated logging styles.