### PR TITLE
update the metabuildpacks to use procfile-cnb tag

### DIFF
--- a/meta-buildpacks/nodejs/CHANGELOG.md
+++ b/meta-buildpacks/nodejs/CHANGELOG.md
@@ -3,6 +3,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+* Update `heroku/procfile` to reference tag
 
 ## [0.3.2] 2021/03/08
 * Upgraded `heroku/nodejs-typescript` to `0.2.2`

--- a/meta-buildpacks/nodejs/package.toml
+++ b/meta-buildpacks/nodejs/package.toml
@@ -14,4 +14,4 @@ uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-yarn-buildpack@sh
 uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-typescript-buildpack@sha256:accfc74412af9702c86d370f6289dc9674acc33023369e68f9687b6b4a1b63bd"
 
 [[dependencies]]
-uri = "docker://docker.io/heroku/procfile-cnb@sha256:b078c148796dd3cff2bb1ac7a0632cf9f4b558bda3161cd0f869010f72c87558"
+uri = "docker://docker.io/heroku/procfile-cnb:0.6.2"

--- a/test/meta-buildpacks/nodejs/package.toml
+++ b/test/meta-buildpacks/nodejs/package.toml
@@ -14,5 +14,4 @@ uri = "../../../buildpacks/yarn"
 uri = "../../../buildpacks/typescript"
 
 [[dependencies]]
-# Should be urn:cnb:registry:heroku/procfile@0.6.1 as soon as pack supports it. (0.16.1?)
-uri = "docker://docker.io/heroku/procfile-cnb@sha256:b078c148796dd3cff2bb1ac7a0632cf9f4b558bda3161cd0f869010f72c87558"
+uri = "docker://docker.io/heroku/procfile-cnb:0.6.2"


### PR DESCRIPTION
Update the metabuildpacks to reference `procfile-cnb` from their tags instead of the sha, so there isn't sha conflicts with other buildpacks downstream.

Possibly related to: https://github.com/buildpacks/pack/issues/1081